### PR TITLE
Support Databox API version 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Change Log
+Following guidelines of http://keepachangelog.com/
+
+## [Unreleased]
+- update to support Databox API version 3
+
+## [0.1.2] - Feb 1, 2016
+- Support for additional attributes on KPI
+- Support for GET /lastpushes
+- Updated and fixed test suite
+- README.md updates.
+
+## [0.1.0] - Jan 4, 2016
+- First official public release of Databox for Go.
+
+## [0.0.1] - Jun 10, 2015
+- Push KPIs with Push()
+- Retrieve information about last push with LastPush()
+- Magical test suite w/ TravisCI support
+- Some documentation to get you going
+
+[Unreleased]: https://github.com/databox/databox-go/compare/0.1.2...master
+[0.1.2]: https://github.com/databox/databox-go/compare/0.1.0...0.1.2
+[0.1.0]: https://github.com/databox/databox-go/compare/0.0.1...0.1.0
+[0.0.1]: https://github.com/databox/databox-go/tree/0.0.1


### PR DESCRIPTION
Update SDK to support Databox API version 3

changes:
- [x] update `GET /lastpushes`
- [x] implement `GET /metrickeys` to return metric keys
- [x] implement `DELETE /data`
- [x] handle new response
