### PR TITLE
Fixing API response handling

### DIFF
--- a/databox.go
+++ b/databox.go
@@ -92,7 +92,7 @@ var postRequest = func(client *Client, path string, payload []byte) ([]byte, err
 		return data, err3
 	}
 
-	if response.StatusCode != 200 {
+	if response.StatusCode < 200 || response.StatusCode > 299 {
 		var responseStatus = &ResponseStatus{}
 		json.Unmarshal(data, &responseStatus)
 		err4 := errors.New(responseStatus.Type + ": " + responseStatus.Message)


### PR DESCRIPTION
API responds with 201, code incorrectly expects exactly 200.

When making successful requests, get back an error string that says `: ` and nothing more, because there isn't actually an error and the `errors.New` fails to construct a proper error message.

This means that in https://developers.databox.com/sdks/ you need to fix the `error != nil` to actually be `== nil` before you say it was "successful".